### PR TITLE
Add comparison against a RWMutex implementation

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,87 @@
+package fastbloom_test
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+)
+
+const fpRate float64 = 0.01
+
+func benchmarkFilterAdd_SingleThreaded(b *testing.B, add func(key []byte)) {
+	b.StopTimer()
+	data := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		data[i] = []byte(strconv.Itoa(i))
+	}
+	b.StartTimer()
+
+	for n := 0; n < b.N; n++ {
+		add(data[n])
+	}
+}
+
+func benchmarkFilter_Add_4ConcurrentWriters(b *testing.B, add func(key []byte)) {
+	b.StopTimer()
+	data := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		data[i] = []byte(strconv.Itoa(i))
+	}
+	workers := 4
+	wg := sync.WaitGroup{}
+	wg.Add(workers)
+	b.StartTimer()
+
+	for w := 0; w < workers; w++ {
+		start := b.N / workers * w
+		end := b.N / workers * (w + 1)
+
+		go func() {
+			for i := start; i < end; i++ {
+				add(data[i])
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func benchmarkFilterTest_SingleThreaded(b *testing.B, add func(key []byte), test func(key []byte) bool) {
+	b.StopTimer()
+	data := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		data[i] = []byte(strconv.Itoa(i))
+		add(data[i])
+	}
+	b.StartTimer()
+
+	for n := 0; n < b.N; n++ {
+		test(data[n])
+	}
+}
+
+func benchmarkFilter_Test_4ConcurrentReaders(b *testing.B, add func(key []byte), test func(key []byte) bool) {
+	b.StopTimer()
+	data := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		data[i] = []byte(strconv.Itoa(i))
+		add(data[i])
+	}
+	workers := 4
+	wg := sync.WaitGroup{}
+	wg.Add(workers)
+	b.StartTimer()
+
+	for w := 0; w < workers; w++ {
+		start := b.N / workers * w
+		end := b.N / workers * (w + 1)
+
+		go func() {
+			for i := start; i < end; i++ {
+				test(data[i])
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}

--- a/lockfree.go
+++ b/lockfree.go
@@ -55,7 +55,7 @@ func (f *LockFreeFilter) Test(key []byte) bool {
 	for i := uint(0); i < f.k; i++ {
 		offset := (uint(lower) + uint(upper)*i) % f.m
 
-		if !f.getBit(offset) {
+		if !f.getBitAtomic(offset) {
 			return false
 		}
 	}
@@ -71,7 +71,7 @@ func (f *LockFreeFilter) Add(key []byte) {
 	// Set all k bits to 1
 	for i := uint(0); i < f.k; i++ {
 		offset := (uint(lower) + uint(upper)*i) % f.m
-		f.setBit(offset)
+		f.setBitAtomic(offset)
 	}
 }
 
@@ -85,9 +85,9 @@ func (f *LockFreeFilter) TestAndAdd(key []byte) bool {
 	for i := uint(0); i < f.k; i++ {
 		offset := (uint(lower) + uint(upper)*i) % f.m
 
-		if !f.getBit(offset) {
+		if !f.getBitAtomic(offset) {
 			member = false
-			f.setBit(offset)
+			f.setBitAtomic(offset)
 		}
 	}
 
@@ -105,7 +105,7 @@ func (f *LockFreeFilter) hash(data []byte) (uint32, uint32) {
 	return higher, lower
 }
 
-func (f *LockFreeFilter) getBit(offset uint) bool {
+func (f *LockFreeFilter) getBitAtomic(offset uint) bool {
 	index := offset / 32
 	bit := offset % 32
 	mask := uint32(1 << bit)
@@ -115,7 +115,7 @@ func (f *LockFreeFilter) getBit(offset uint) bool {
 	return b&mask != 0
 }
 
-func (f *LockFreeFilter) setBit(offset uint) {
+func (f *LockFreeFilter) setBitAtomic(offset uint) {
 	index := offset / 32
 	bit := offset % 32
 	mask := uint32(1 << bit)

--- a/lockfree.go
+++ b/lockfree.go
@@ -11,9 +11,9 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-// Filter is an implementation of a Bloom Filter that permits n concurrent
+// LockFreeFilter is an implementation of a Bloom LockFreeFilter that permits n concurrent
 // readers and m concurrent writers.
-type Filter struct {
+type LockFreeFilter struct {
 	data []uint32 // underlying bit vector
 	m    uint     // filter size
 	k    uint     // number of hash functions
@@ -24,9 +24,9 @@ type Filter struct {
 const fillRatio = 0.5
 
 // NewFilter creates a bloom filter optimized for n elements with a falsePositive rate fpRate.
-func NewFilter(n uint, fpRate float64) *Filter {
+func NewFilter(n uint, fpRate float64) *LockFreeFilter {
 	m := optimalM(n, fpRate)
-	return &Filter{
+	return &LockFreeFilter{
 		data:     make([]uint32, m/32+1),
 		m:        m,
 		k:        optimalK(fpRate),
@@ -35,12 +35,12 @@ func NewFilter(n uint, fpRate float64) *Filter {
 }
 
 // Capacity returns the Bloom filter capacity, m.
-func (f *Filter) Capacity() uint {
+func (f *LockFreeFilter) Capacity() uint {
 	return f.m
 }
 
 // K returns the number of hash functions.
-func (f *Filter) K() uint {
+func (f *LockFreeFilter) K() uint {
 	return f.k
 }
 
@@ -48,7 +48,7 @@ func (f *Filter) K() uint {
 // true after a call to Add(key) or TestAndAdd(key) have completed. Because of
 // the possibility of false positives, Test(key) could also return true if the key
 // hasn't been added.
-func (f *Filter) Test(key []byte) bool {
+func (f *LockFreeFilter) Test(key []byte) bool {
 	lower, upper := f.hash(key)
 
 	// If any of the K bits are not set, then it's not a member.
@@ -65,7 +65,7 @@ func (f *Filter) Test(key []byte) bool {
 
 // Add writes a key to the bloom filter. It can be called concurrently with other
 // calls to Add, TestAndAdd, and Test.
-func (f *Filter) Add(key []byte) *Filter {
+func (f *LockFreeFilter) Add(key []byte) {
 	lower, upper := f.hash(key)
 
 	// Set all k bits to 1
@@ -73,13 +73,11 @@ func (f *Filter) Add(key []byte) *Filter {
 		offset := (uint(lower) + uint(upper)*i) % f.m
 		f.setBit(offset)
 	}
-
-	return f
 }
 
 // TestAndAdd adds a key to the bloom filter and returns true if it appears that
 // the key was already present.
-func (f *Filter) TestAndAdd(key []byte) bool {
+func (f *LockFreeFilter) TestAndAdd(key []byte) bool {
 	lower, upper := f.hash(key)
 	member := true
 
@@ -96,7 +94,7 @@ func (f *Filter) TestAndAdd(key []byte) bool {
 	return member
 }
 
-func (f *Filter) hash(data []byte) (uint32, uint32) {
+func (f *LockFreeFilter) hash(data []byte) (uint32, uint32) {
 	h := f.hashPool.Get().(hash.Hash64)
 	h.Write(data)
 	sum := h.Sum64()
@@ -107,7 +105,7 @@ func (f *Filter) hash(data []byte) (uint32, uint32) {
 	return higher, lower
 }
 
-func (f *Filter) getBit(offset uint) bool {
+func (f *LockFreeFilter) getBit(offset uint) bool {
 	index := offset / 32
 	bit := offset % 32
 	mask := uint32(1 << bit)
@@ -117,7 +115,7 @@ func (f *Filter) getBit(offset uint) bool {
 	return b&mask != 0
 }
 
-func (f *Filter) setBit(offset uint) {
+func (f *LockFreeFilter) setBit(offset uint) {
 	index := offset / 32
 	bit := offset % 32
 	mask := uint32(1 << bit)
@@ -134,7 +132,7 @@ func (f *Filter) setBit(offset uint) {
 }
 
 // GobEncode implements gob.GobEncoder interface.
-func (f *Filter) GobEncode() ([]byte, error) {
+func (f *LockFreeFilter) GobEncode() ([]byte, error) {
 	filter := &pb.Filter{
 		M:    uint64(f.m),
 		K:    uint64(f.k),
@@ -144,13 +142,13 @@ func (f *Filter) GobEncode() ([]byte, error) {
 }
 
 // GobDecode implements gob.GobDecoder interface.
-func (f *Filter) GobDecode(data []byte) error {
+func (f *LockFreeFilter) GobDecode(data []byte) error {
 	filter := &pb.Filter{}
 	if err := proto.Unmarshal(data, filter); err != nil {
 		return err
 	}
 
-	*f = Filter{
+	*f = LockFreeFilter{
 		m:        uint(filter.M),
 		k:        uint(filter.K),
 		data:     filter.Data,

--- a/mutex.go
+++ b/mutex.go
@@ -1,0 +1,84 @@
+package fastbloom
+
+import (
+	"sync"
+)
+
+type MutexFilter struct {
+	*LockFreeFilter
+	sync.RWMutex
+}
+
+func NewMutexFilter(n uint, fpRate float64) *MutexFilter {
+	return &MutexFilter{LockFreeFilter: NewFilter(n, fpRate)}
+}
+
+func (f *MutexFilter) Test(key []byte) bool {
+	f.RLock()
+	defer f.RUnlock()
+
+	lower, upper := f.hash(key)
+
+	// If any of the K bits are not set, then it's not a member.
+	for i := uint(0); i < f.k; i++ {
+		offset := (uint(lower) + uint(upper)*i) % f.m
+
+		if !f.getBit(offset) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (f *MutexFilter) Add(key []byte) {
+	f.Lock()
+	defer f.Unlock()
+
+	lower, upper := f.hash(key)
+
+	// Set all k bits to 1
+	for i := uint(0); i < f.k; i++ {
+		offset := (uint(lower) + uint(upper)*i) % f.m
+		f.setBit(offset)
+	}
+}
+
+func (f *MutexFilter) TestAndAdd(key []byte) bool {
+	f.Lock()
+	defer f.Unlock()
+
+	lower, upper := f.hash(key)
+	member := true
+
+	// If any of the K bits are not set, then it's not a member.
+	for i := uint(0); i < f.k; i++ {
+		offset := (uint(lower) + uint(upper)*i) % f.m
+
+		if !f.getBit(offset) {
+			member = false
+			f.setBit(offset)
+		}
+	}
+
+	return member
+}
+
+func (f *MutexFilter) getBit(offset uint) bool {
+	index := offset / 32
+	bit := offset % 32
+	mask := uint32(1 << bit)
+
+	b := f.data[index]
+	return b&mask != 0
+}
+
+func (f *MutexFilter) setBit(offset uint) {
+	index := offset / 32
+	bit := offset % 32
+	mask := uint32(1 << bit)
+
+	orig := f.data[index]
+	updated := orig | mask
+	f.data[index] = updated
+}

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -1,0 +1,35 @@
+package fastbloom_test
+
+import (
+	"testing"
+
+	"github.com/JamesHageman/fastbloom"
+)
+
+func BenchmarkMutexFilter_Add_SingleThreaded(b *testing.B) {
+	b.StopTimer()
+	f := fastbloom.NewMutexFilter(uint(b.N), fpRate)
+	b.StartTimer()
+	benchmarkFilterAdd_SingleThreaded(b, f.Add)
+}
+
+func BenchmarkMutexFilter_Add_4ConcurrentWriters(b *testing.B) {
+	b.StopTimer()
+	f := fastbloom.NewMutexFilter(uint(b.N), fpRate)
+	b.StartTimer()
+	benchmarkFilter_Add_4ConcurrentWriters(b, f.Add)
+}
+
+func BenchmarkMutexFreeFilter_Test_SingleThreaded(b *testing.B) {
+	b.StopTimer()
+	f := fastbloom.NewMutexFilter(uint(b.N), fpRate)
+	b.StartTimer()
+	benchmarkFilterTest_SingleThreaded(b, f.Add, f.Test)
+}
+
+func BenchmarkMutexFreeFilter_Test_4ConcurrentReaders(b *testing.B) {
+	b.StopTimer()
+	f := fastbloom.NewMutexFilter(uint(b.N), fpRate)
+	b.StartTimer()
+	benchmarkFilter_Test_4ConcurrentReaders(b, f.Add, f.Test)
+}

--- a/proto/filter.pb.go
+++ b/proto/filter.pb.go
@@ -5,8 +5,9 @@ package filter
 
 import (
 	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
 	math "math"
+
+	proto "github.com/golang/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -76,7 +77,7 @@ func (m *Filter) GetData() []uint32 {
 }
 
 func init() {
-	proto.RegisterType((*Filter)(nil), "Filter")
+	proto.RegisterType((*Filter)(nil), "LockFreeFilter")
 }
 
 func init() { proto.RegisterFile("filter.proto", fileDescriptor_1f5303cab7a20d6f) }


### PR DESCRIPTION
```
go test -test.bench ".*" -test.benchmem .
goos: darwin
goarch: amd64
pkg: github.com/JamesHageman/fastbloom
BenchmarkLockFreeAdd_SingleThreaded-12                 	20000000	       125 ns/op	       0 B/op	       0 allocs/op
BenchmarkLockFreeAdd_4ConcurrentWriters-12             	50000000	        36.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkLockFreeFilter_Test_SingleThreaded-12         	20000000	       101 ns/op	       0 B/op	       0 allocs/op
BenchmarkLockFreeFilter_Test_4ConcurrentReaders-12     	100000000	        28.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkMutexFilter_Add_SingleThreaded-12             	10000000	       139 ns/op	       0 B/op	       0 allocs/op
BenchmarkMutexFilter_Add_4ConcurrentWriters-12         	10000000	       187 ns/op	       0 B/op	       0 allocs/op
BenchmarkMutexFreeFilter_Test_SingleThreaded-12        	10000000	       132 ns/op	       0 B/op	       0 allocs/op
BenchmarkMutexFreeFilter_Test_4ConcurrentReaders-12    	20000000	        82.2 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/JamesHageman/fastbloom	51.638s
```